### PR TITLE
apply sensible default to geom_col orientation

### DIFF
--- a/R/histogram.R
+++ b/R/histogram.R
@@ -89,7 +89,8 @@ dbplot_histogram <- function(data, x, bins = 30, binwidth = NULL) {
   )
 
   ggplot(df) +
-    geom_col(aes(x, count)) +
+    geom_col(aes(x, count),
+             orientation = "x") +
     labs(
       x = quo_name(x),
       y = "count"


### PR DESCRIPTION
- setting `orientation` args of `geom_col()` to `x`, plot will show vertical bars, commonly used for histograms